### PR TITLE
Allow servoWrite to pass values in degrees or nanoseconds

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105,6 +105,10 @@ function bufferToArray(buffer) {
   return array;
 }
 
+function constrain(value, min, max) {
+  return value > max ? max : value < min ? min : value;
+}
+
 var RaspiIOCore = exports.RaspiIOCore = function (_EventEmitter) {
   _inherits(RaspiIOCore, _EventEmitter);
 
@@ -667,7 +671,12 @@ var RaspiIOCore = exports.RaspiIOCore = function (_EventEmitter) {
         this.pinMode(pin, SERVO_MODE);
       }
       var period = 1000000 / pinInstance.peripheral.frequency; // in us
-      var pulseWidth = pinInstance.min + value / 180 * (pinInstance.max - pinInstance.min); // in us
+      var pulseWidth;
+      if (value < 544) {
+        pulseWidth = pinInstance.min + constrain(value, 0, 180) / 180 * (pinInstance.max - pinInstance.min);
+      } else {
+        pulseWidth = constrain(value, pinInstance.min, pinInstance.max);
+      }
       pinInstance.peripheral.write(pulseWidth / period);
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,10 @@ function bufferToArray(buffer) {
   return array;
 }
 
+function constrain(value, min, max) {
+  return value > max ? max : value < min ? min : value;
+}
+
 export class RaspiIOCore extends EventEmitter {
 
   constructor(options) {
@@ -620,7 +624,12 @@ export class RaspiIOCore extends EventEmitter {
       this.pinMode(pin, SERVO_MODE);
     }
     const period = 1000000 / pinInstance.peripheral.frequency; // in us
-    const pulseWidth = (pinInstance.min + (value / 180) * (pinInstance.max - pinInstance.min)); // in us
+    var pulseWidth;
+    if (value < 544) {
+      pulseWidth = pinInstance.min + constrain(value, 0, 180) / 180 * (pinInstance.max - pinInstance.min);
+    } else {
+      pulseWidth = constrain(value, pinInstance.min, pinInstance.max);
+    }
     pinInstance.peripheral.write(pulseWidth / period);
   }
 


### PR DESCRIPTION
This matches the functionality of firmata. There is an upcoming change in Johnny-Five that will send servo values in nanoseconds instead of degrees. That will give us better positioning accuracy and will allow us to support non-180° servos.

This change has already been implemented in linux-io (and by extension beagle bone), tessel-io, and is coming soon for imp-io and particle-io. Not sure we will bother with discontinued platforms unless someone asks.

This also adds constrain to make sure we don’t try to write invalid values.